### PR TITLE
Specify a radix when calling `parseInt`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "authors": [

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* global define */
 (function (root, factory) {
     /* istanbul ignore next */
     if (typeof define === 'function' && define.amd) {
@@ -6,7 +7,7 @@
         module.exports = factory();
     } else {
         root.returnExports = factory();
-  }
+    }
 }(this, function () {
 
     var patchPattern = /-([\w-.]+)/;

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@
         var s2 = split(v2);
 
         for (var i = 0; i < 3; i++) {
-            var n1 = parseInt(s1[i] || 0);
-            var n2 = parseInt(s2[i] || 0);
+            var n1 = parseInt(s1[i] || 0, 10);
+            var n2 = parseInt(s2[i] || 0, 10);
 
             if (n1 > n2) return 1;
             if (n2 > n1) return -1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
From [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt):
_"Always specify this parameter to eliminate reader confusion and to guarantee predictable behavior. Different implementations produce different results when a radix is not specified."_
