### PR TITLE
Move patch check outside of the `for` loop

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "authors": [

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+/* global define */
 (function (root, factory) {
     /* istanbul ignore next */
     if (typeof define === 'function' && define.amd) {
@@ -6,7 +7,7 @@
         module.exports = factory();
     } else {
         root.returnExports = factory();
-  }
+    }
 }(this, function () {
 
     var patchPattern = /-([\w-.]+)/;

--- a/index.js
+++ b/index.js
@@ -29,16 +29,16 @@
 
             if (n1 > n2) return 1;
             if (n2 > n1) return -1;
+        }
 
-            if (i === 2 && (s1[i] + s2[i]).indexOf('-') > -1) {
-                var p1 = (patchPattern.exec(s1[i]) || [''])[0];
-                var p2 = (patchPattern.exec(s2[i]) || [''])[0];
+        if ((s1[2] + s2[2]).indexOf('-') > -1) {
+            var p1 = (patchPattern.exec(s1[2]) || [''])[0];
+            var p2 = (patchPattern.exec(s2[2]) || [''])[0];
 
-                if (p1 === '') return 1;
-                if (p2 === '') return -1;
-                if (p1 > p2) return 1;
-                if (p2 > p1) return -1;
-            }
+            if (p1 === '') return 1;
+            if (p2 === '') return -1;
+            if (p1 > p2) return 1;
+            if (p2 > p1) return -1;
         }
 
         return 0;

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@
         var s2 = split(v2);
 
         for (var i = 0; i < 3; i++) {
-            var n1 = parseInt(s1[i] || 0);
-            var n2 = parseInt(s2[i] || 0);
+            var n1 = parseInt(s1[i] || 0, 10);
+            var n2 = parseInt(s2[i] || 0, 10);
 
             if (n1 > n2) return 1;
             if (n2 > n1) return -1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compare-versions",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Compare semver version strings to find greater, equal or lesser.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Why do an `if` each time, when we know all we want is the [2] index?
