### PR TITLE
Changed global accessor name to compareVersions

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory();
     } else {
-        root.returnExports = factory();
+        root.compareVersions = factory();
     }
 }(this, function () {
 


### PR DESCRIPTION
I find current `returnExports` visible in my root scope (global `window` object in browser) pretty cryptic and not descriptive.
I'd expect the global accessor to match the name of the function instead, so that I know what is that thing I'm calling:

`window.compareVersions('1.1', '1.2')`
instead of:
`window.returnExports('1.1', '1.2')`
