### PR TITLE
Ensure single-segment versions are compared correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@
             if (n2 > n1) return -1;
         }
 
+        s1[2] = s1[2] || '';
+        s2[2] = s2[2] || '';
+
         if ((s1[2] + s2[2]).indexOf('-') > -1) {
             var p1 = (patchPattern.exec(s1[2]) || [''])[0];
             var p2 = (patchPattern.exec(s2[2]) || [''])[0];

--- a/test/compare.js
+++ b/test/compare.js
@@ -2,10 +2,22 @@ var assert = require('assert');
 var compare = require('..');
 
 describe('compare versions', function () {
-    it('should compare versions correctly', function () {
+    it('should compare three-segment versions correctly', function () {
         assert.equal(compare('10.1.8', '10.0.4'),  1);
         assert.equal(compare('10.0.1', '10.0.1'),  0);
         assert.equal(compare('10.1.1', '10.2.2'), -1);
+    });
+
+    it('should compare two-segment versions correctly', function () {
+        assert.equal(compare('10.8', '10.4'),  1);
+        assert.equal(compare('10.1', '10.1'),  0);
+        assert.equal(compare('10.1', '10.2'), -1);
+    });
+
+    it('should compare single-segment versions correctly', function () {
+        assert.equal(compare('10', '9'),  1);
+        assert.equal(compare('10', '10'),  0);
+        assert.equal(compare('9', '10'), -1);
     });
 
     it('should compare versions with different number of digits in same group', function () {


### PR DESCRIPTION
Before that fix, comparison between plain single-segment versions like '5' and '6' fail with
`TypeError: (s1[2] + s2[2]).indexOf is not a function(…)`, because both `s1[2]` and `s2[2]` were undefined.
