### PR TITLE
Handle garbage input more gracefully

### DIFF
--- a/test/compare.js
+++ b/test/compare.js
@@ -61,4 +61,10 @@ describe('compare versions', function () {
         assert.equal(compare('1.4.0-build.3928', '1.4.0-build.3928+sha.a8d9d4f'), 0);
         assert.equal(compare('1.4.0-build.3928+sha.b8dbdb0', '1.4.0-build.3928+sha.a8d9d4f'), 0);
     });
+
+    describe('bad input', function () {
+        it('should compare bad input successfully', function () {
+            assert.notEqual(compare('1.0', 'foo'), 0);
+        });
+    });
 });


### PR DESCRIPTION
**Not ready to merge** 

Right now this is just a failing test:

```
assert.notEqual(compare('1.0', 'foo'), 0);
```

I'm not 100% sure what the right approach is but my instinct is that if we fail to normalize a string into a "version" we could just fall back to using `>` and `<` operators? 
