### PR TITLE
style: changed typescript declaration default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,19 @@ $ npm install compare-versions
 
 ## Usage
 
+Javascript import
 ```javascript
 var compareVersions = require('compare-versions');
 
 compareVersions('10.1.8', '10.0.4'); //  1
 compareVersions('10.0.1', '10.0.1'); //  0
 compareVersions('10.1.1', '10.2.2'); // -1
+```
+
+TypeScript import
+
+```javascript
+import compareVersions from 'compare-versions';
 ```
 
 Can also be used for sorting:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
 declare function compareVersions(firstVersion: string, secondVersion: string): number;
-export = compareVersions;
+export default compareVersions;


### PR DESCRIPTION
The current implementation makes importing very difficult in TypeScript.

We had to do something like
```javascript
const compareVersions = require('compare-version');
```
which is not very useful for importing types because you can do ```require()``` anyway withouth index.d.ts

My change provides a default export function so now we can do
```javascript
import compareVersions from 'compare-versions';
```
which imports the types, and it looks better in TypeScript.

I have updated the README.md as well.