### PR TITLE
fix for ' resolves to a non-module entity '

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,3 @@
 declare function compareVersions(firstVersion: string, secondVersion: string): number;
+declare namespace compareVersions {}
 export = compareVersions;


### PR DESCRIPTION
fixes error: 
```
ERROR in src/../../../*.ts(16,34): error TS2497:
Module '"*/node_modules/compare-versions/index"' resolves to a non-module entity and cannot be imported using this construct.
```