### PR TITLE
feat(validate): expose validate function with boolean return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ compareVersions.compare('10.1.1', '10.2.2', '>='); // return false
 Applies the same ruleset as used before comparing version numbers and returns a boolean:
 
 ```javascript
-compareVersions.validate('1.0.0-rc.1'); //  true
-compareVersions.validate('1.0-rc.1'); //  false
-compareVersions.validate(1.0); //  false
+compareVersions.validate('1.0.0-rc.1'); // return true
+compareVersions.validate('1.0-rc.1'); // return false
+compareVersions.validate('foo'); // return false
 ```
 
 ### Browser

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ compareVersions.compare('10.1.1', '10.2.2', '<='); // return true
 compareVersions.compare('10.1.1', '10.2.2', '>='); // return false
 ```
 
+### Validate version numbers
+
+Applies the same ruleset as used before comparing version numbers and returns a boolean:
+
+```javascript
+compareVersions.validate('1.0.0-rc.1'); //  true
+compareVersions.validate('1.0-rc.1'); //  false
+compareVersions.validate(1.0); //  false
+```
+
 ### Browser
 
 If included directly in the browser, `compareVersions()` is available on the global window:

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,23 @@ declare const compareVersions: {
     secondVersion: string, 
     operator: compareVersions.CompareOperator
   ): boolean;
+
+  /**
+   * Validate [semver](https://semver.org/) version strings.
+   * 
+   * @param version Version number to validate
+   * @returns `true` if the version number is a valid semver version number, `false` otherwise.
+   *
+   * @example
+   * ```
+   * compareVersions.validate('1.0.0-rc.1'); // return true
+   * compareVersions.validate('1.0-rc.1'); // return false
+   * compareVersions.validate('foo'); // return false
+   * ```
+   */
+	validate(
+    version: string
+  ): boolean;
 };
 
 export = compareVersions;

--- a/index.js
+++ b/index.js
@@ -97,6 +97,10 @@
     }
   }
 
+  compareVersions.validate = function(version) {
+    return typeof version === 'string' && semver.test(version);
+  }
+
   compareVersions.compare = function (v1, v2, operator) {
     // Validate operator
     validateOperator(operator);

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const compare = require('..');
+
+describe('validate versions', () => {
+  [
+    [undefined, false],
+    [null, false],
+    [42, false],
+    [{}, false],
+    [[], false],
+    [() => undefined, false],
+    ['6.3.', false],
+    ['1.2.3a', false],
+    ['1.2.-3a', false],
+    ['v1.0.0', true],
+    ['01.0.0', true],
+    ['1.0.x', true],
+    ['1.0.0-rc.1', true],
+    ['1.0.0-alpha', true],
+    ['1.0.0-build.3928', true],
+    ['1.0.0+20130313144700', true],
+    ['1.2.3.100', true],
+    ['2020', true]
+  ].forEach(([v, expected]) => {
+    it(`${v}`, () => {
+      assert.equal(compare.validate(v), expected)
+    });
+  });
+});


### PR DESCRIPTION
Implements #37.

First I thought about just exposing the validate function which throws, but that seemed not very nice to always use a try-catch-block, so simplified the conditions and made it a separate function.

Added a couple of tests and documentation.

Would be great to get this shipped soon. Thanks :-)