### PR TITLE
Fix Some Inconsistencies Between CommonJS and ES Modules Export

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,10 @@
     return arr;
   }
 
+  function isWildcard(s) {
+    return s === '*' || s === 'x' || s === 'X';
+  }
+
   function tryParse(v) {
     var n = parseInt(v, 10);
     return isNaN(n) ? v : n;
@@ -48,6 +52,7 @@
   }
 
   function compareStrings(a, b) {
+    if (isWildcard(a) || isWildcard(b)) return 0;
     var [ap, bp] = forceType(tryParse(a), tryParse(b));
     if (ap > bp) return 1;
     if (ap < bp) return -1;

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@
   }
 
   compareVersions.validate = function (version) {
-    return typeof version === 'string' && semver.test(version);
+    return typeof version === 'string' && /^[v\d]/.test(version) && semver.test(version);
   };
 
   compareVersions.compare = function (v1, v2, operator) {

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@
       var p1 = sp1.split('.').map(tryParse);
       var p2 = sp2.split('.').map(tryParse);
 
-      for (i = 0; i < Math.max(p1.length, p2.length); i++) {
+      for (var i = 0; i < Math.max(p1.length, p2.length); i++) {
         if (
           p1[i] === undefined ||
           (typeof p2[i] === 'string' && typeof p1[i] === 'number')


### PR DESCRIPTION
## Investigation

I found that the `validate` test failed using the `index.js` file because it was out of sync with `index.mjs`. I added a few fixes to bridge the gap between the two files.

## Changes

- Added additional validation logic in the `validate` function in `index.js`
- Added `isWildcard` check to `compareStrings` function in `index.js`
- Added missing `var` within for loop in `index.js`

## Extra

I was able to spot these because I am working on a version of compare-versions [here](https://github.com/jvanderen1/compare-versions). In this project, it would be contain a single source of truth which compiles to both CommonJS and ES Modules syntax. If anyone is interested, let me know.