### PR TITLE
fix(esm): add .js extension to imports

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,5 +1,5 @@
-import { compareVersions } from './compareVersions';
-import { CompareOperator } from './utils';
+import { compareVersions } from './compareVersions.js';
+import { CompareOperator } from './utils.js';
 
 /**
  * Compare [semver](https://semver.org/) version strings using the specified operator.

--- a/src/compareVersions.ts
+++ b/src/compareVersions.ts
@@ -1,4 +1,4 @@
-import { compareSegments, validateAndParse } from './utils';
+import { compareSegments, validateAndParse } from './utils.js';
 
 /**
  * Compare [semver](https://semver.org/) version strings to find greater, equal or lesser.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { compare } from './compare';
-export { compareVersions } from './compareVersions';
-export { satisfies } from './satisfies';
-export { CompareOperator } from './utils';
-export { validate, validateStrict } from './validate';
+export { compare } from './compare.js';
+export { compareVersions } from './compareVersions.js';
+export { satisfies } from './satisfies.js';
+export { CompareOperator } from './utils.js';
+export { validate, validateStrict } from './validate.js';

--- a/src/satisfies.ts
+++ b/src/satisfies.ts
@@ -1,5 +1,5 @@
-import { compare } from './compare';
-import { CompareOperator, compareSegments, validateAndParse } from './utils';
+import { compare } from './compare.js';
+import { CompareOperator, compareSegments, validateAndParse } from './utils.js';
 
 /**
  * Match [npm semver](https://docs.npmjs.com/cli/v6/using-npm/semver) version range.

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,4 +1,4 @@
-import { semver } from './utils';
+import { semver } from './utils.js';
 
 /**
  * Validate [semver](https://semver.org/) version strings.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,18 @@
 {
-	"compilerOptions": {
-		"declaration": true,
-		"esModuleInterop": true,
-		"module": "UMD",
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"outDir": ".",
-		"sourceMap": true,
-		"strict": true,
-		"target": "ES5"
-	},
-	"include": [
-		"src/index.ts"
-	],
-	"exclude": [
-		"./src/test/**/*",
-		"node_modules"
-	]
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "module": "UMD",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": ".",
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES5"
+  },
+  "include": ["src/index.ts"],
+  "exclude": ["./src/test/**/*", "node_modules"],
+  "ts-node": {
+    "experimentalResolver": true
+  }
 }


### PR DESCRIPTION
This will output ESM valid imports.

~However this also breaks unit testing as c8/mocha does not understand .js and is expecting .ts.~

Fix: ts-node has experimentalResolver setting to map .js > .ts
